### PR TITLE
Name threadpool. Explicitly set connection pool. More comprehensive close().

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 allprojects {
     group = 'com.launchdarkly'
-    version = "0.2.3"
+    version = "0.2.4-SNAPSHOT"
     sourceCompatibility = 1.7
     targetCompatibility = 1.7
 }
@@ -20,6 +20,7 @@ allprojects {
 dependencies {
     compile "com.squareup.okhttp3:okhttp:3.2.0"
     compile "org.slf4j:slf4j-api:1.7.7"
+    compile "com.google.guava:guava:19.0"
     testRuntime "ch.qos.logback:logback-classic:1.1.3"
     testCompile "org.mockito:mockito-core:1.10.19"
     testCompile "junit:junit:4.11"


### PR DESCRIPTION
When load testing ld-relay I came across thread leakage when using this library. These changes eliminate the leak.