### PR TITLE
Add onClosed event handler.

### DIFF
--- a/src/main/java/com/launchdarkly/eventsource/AsyncEventHandler.java
+++ b/src/main/java/com/launchdarkly/eventsource/AsyncEventHandler.java
@@ -27,6 +27,18 @@ class AsyncEventHandler implements EventHandler {
     });
   }
 
+  public void onClosed() {
+    executor.execute(new Runnable() {
+      public void run() {
+        try {
+          eventSourceHandler.onClosed();
+        } catch (Exception e) {
+          onError(e);
+        }
+      }
+    });
+  }
+
   public void onComment(final String comment) {
     executor.execute(new Runnable() {
       public void run() {

--- a/src/main/java/com/launchdarkly/eventsource/EventHandler.java
+++ b/src/main/java/com/launchdarkly/eventsource/EventHandler.java
@@ -2,6 +2,7 @@ package com.launchdarkly.eventsource;
 
 public interface EventHandler {
   void onOpen() throws Exception;
+  void onClosed() throws Exception;
   void onMessage(String event, MessageEvent messageEvent) throws Exception;
   void onComment(String comment) throws Exception;
   void onError(Throwable t);

--- a/src/main/java/com/launchdarkly/eventsource/EventSource.java
+++ b/src/main/java/com/launchdarkly/eventsource/EventSource.java
@@ -83,6 +83,13 @@ public class EventSource implements ConnectionHandler, Closeable {
     if (currentState == SHUTDOWN) {
       return;
     }
+    if (currentState == ReadyState.OPEN) {
+      try {
+        handler.onClosed();
+      } catch (Exception e) {
+        handler.onError(e);
+      }
+    }
     executor.shutdownNow();
 
     if (client != null) {
@@ -149,6 +156,13 @@ public class EventSource implements ConnectionHandler, Closeable {
           }
           if (call != null) {
             call.cancel();
+          }
+          if (currentState == ReadyState.OPEN) {
+            try {
+              handler.onClosed();
+            } catch (Exception e) {
+              handler.onError(e);
+            }
           }
         }
       }


### PR DESCRIPTION
Closes #12

Happy to re-work this one if needed.

Opted to go for onClosed rather than onReadyStateChange as that was more useful.

I wasn't quite sure where to put the onClosed call so put it in close() and in connect(), in both cases it only fires if the previous state was OPEN so there shouldn't be any cases of it double-firing.

This means that the event will fire if the user calls close(), or if the socket ends up getting closed by other means.

Only putting it in connect() seemed mean that a user calling close() didn't get the onClosed event fired quickly as it waited until there was some data on the socket to read before it ultimately got round to calling the finally block.