### PR TITLE
Ensure that connections are closed completely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,11 @@
 *.ipr
 *.iws
 .idea/
+local.properties
  
 #Gradle
 .gradletasknamecache
 .gradle/
 build/
 bin/
+

--- a/src/test/java/com/launchdarkly/eventsource/ManualTest.java
+++ b/src/test/java/com/launchdarkly/eventsource/ManualTest.java
@@ -40,11 +40,7 @@ public class ManualTest {
     logger.warn("Sleeping...");
     Thread.sleep(10000L);
     logger.debug("Stopping source");
-    try {
-      source.close();
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    source.close();
     logger.debug("Stopped");
   }
 }


### PR DESCRIPTION
Connections in OkHttp are not closed unless the response body itself is closed. These changes ensure that the response bodies are consumed, and therefore the responses can be closed.