### PR TITLE
Fix removing extra space from event

### DIFF
--- a/src/main/java/com/launchdarkly/eventsource/EventParser.java
+++ b/src/main/java/com/launchdarkly/eventsource/EventParser.java
@@ -43,7 +43,10 @@ public class EventParser {
       processComment(line.substring(1).trim());
     } else if ((colonIndex = line.indexOf(":")) != -1) {
       String field = line.substring(0, colonIndex);
-      String value = line.substring(colonIndex + 1).replaceFirst(" ", EMPTY_STRING);
+      String value = line.substring(colonIndex + 1);
+      if (value.charAt(0)==' ') {
+        value = value.replaceFirst(" ", EMPTY_STRING);
+      }
       processField(field, value);
     } else {
       processField(line.trim(), EMPTY_STRING); // The spec doesn't say we need to trim the line, but I assume that's an oversight.

--- a/src/test/java/com/launchdarkly/eventsource/EventParserTest.java
+++ b/src/test/java/com/launchdarkly/eventsource/EventParserTest.java
@@ -118,4 +118,22 @@ public class EventParserTest {
     verify(eventHandler).onMessage(eq("message"), eq(new MessageEvent("hello", "reused", ORIGIN)));
     verify(eventHandler).onMessage(eq("message"), eq(new MessageEvent("world", "reused", ORIGIN)));
   }
+
+  @Test
+  public void filtersOutFirstSpace() throws Exception {
+    parser.line("data: {\"foo\": \"bar baz\"}");
+    parser.line("");
+
+    verify(eventHandler).onMessage(eq("message"), eq(new MessageEvent("{\"foo\": \"bar baz\"}", null, ORIGIN)));
+    verifyNoMoreInteractions(eventHandler);
+  }
+
+  @Test
+  public void keepsDataIntact() throws Exception {
+    parser.line("data:{\"foo\": \"bar baz\"}");
+    parser.line("");
+
+    verify(eventHandler).onMessage(eq("message"), eq(new MessageEvent("{\"foo\": \"bar baz\"}", null, ORIGIN)));
+    verifyNoMoreInteractions(eventHandler);
+  }
 }


### PR DESCRIPTION
If server sends the following event:
event:FooBar
data:{"foo":"bar baz"}

The first space after the first ':' is removed, becoming:
{"foo":"barbaz"}

This commit should first check if the second part of the line (after ':') starts with a white space.
If it doesn't then it won't replace any space in its content.

I assume this exists to remove the space for cases when the input is in the format:
data: {"foo":"bar baz"}