### PR TITLE
prepare 1.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Change log
+
+All notable changes to the LaunchDarkly EventSource implementation for Java will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
+
+## [1.8.0] - 2018-04-04
+### Added:
+- Added `maxReconnectTimeMs(long)` method to `EventSource.Builder` to override the default maximum reconnect time of 30 seconds
+
+## [1.7.1] - 2018-01-30
+### Changed:
+- Fixed EventSource logger name to match convention
+- Ensure background threads are daemon threads
+- Don't log IOExceptions when the stream is already being shut down
+
+## [1.7.0] - 2018-01-07
+### Added:
+- Added the ability to connect to an SSE resource using any HTTP method (defaults to GET), and specify a request body.
+
+## [1.6.0] - 2017-12-20
+### Added:
+- Add new handler interface for stopping connection retries after an error
+
+### Fixed:
+- Ensure that connections are closed completely ([#24](https://github.com/launchdarkly/okhttp-eventsource/pull/24))
+- Ensure that we reconnect with backoff in case of a read timeout

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Java EventSource implementation based on OkHttp
 Project Information
 -----------
 
-This libary allows Java developers to consume Server Sent Events from a remote API. The server sent events spec is defined here: [https://html.spec.whatwg.org/multipage/server-sent-events.html](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events)
+This library allows Java developers to consume Server Sent Events from a remote API. The server sent events spec is defined here: [https://html.spec.whatwg.org/multipage/server-sent-events.html](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.8.0
+version=1.9.0-SNAPSHOT
 ossrhUsername=
 ossrhPassword=

--- a/src/main/java/com/launchdarkly/eventsource/ConnectionErrorHandler.java
+++ b/src/main/java/com/launchdarkly/eventsource/ConnectionErrorHandler.java
@@ -1,5 +1,10 @@
 package com.launchdarkly.eventsource;
 
+/**
+ * Interface for an object that will be notified when EventSource encounters a connection failure.
+ * This is different from {@link EventHandler#onError(Throwable)} in that it will not be called for
+ * other kinds of errors; also, it has the ability to tell EventSource to stop reconnecting.
+ */
 public interface ConnectionErrorHandler {
   /**
    * Return values of {@link ConnectionErrorHandler#onConnectionError(Throwable)} indicating what
@@ -28,6 +33,9 @@ public interface ConnectionErrorHandler {
    */
   Action onConnectionError(Throwable t);
   
+  /**
+   * Default handler that does nothing.
+   */
   public static final ConnectionErrorHandler DEFAULT = new ConnectionErrorHandler() {
     @Override
     public Action onConnectionError(Throwable t) {

--- a/src/main/java/com/launchdarkly/eventsource/EventHandler.java
+++ b/src/main/java/com/launchdarkly/eventsource/EventHandler.java
@@ -1,10 +1,36 @@
 package com.launchdarkly.eventsource;
 
+/**
+ * Interface for an object that will receive SSE events.
+ */
 public interface EventHandler {
+  /**
+   * EventSource calls this method when the stream connection has been opened.
+   * @throws Exception throwing an exception here will cause it to be logged and also sent to {@link #onError(Throwable)}
+   */
   void onOpen() throws Exception;
+  
+  /**
+   * EventSource calls this method when the stream connection has been closed.
+   * @throws Exception throwing an exception here will cause it to be logged and also sent to {@link #onError(Throwable)}
+   */
   void onClosed() throws Exception;
+  
+  /**
+   * EventSource calls this method when it has received a new event from the stream.
+   * @param event the event name, from the {@code event:} line in the stream  
+   * @param messageEvent a {@link MessageEvent} object containing all the other event properties
+   * @throws Exception throwing an exception here will cause it to be logged and also sent to {@link #onError(Throwable)}
+   */
   void onMessage(String event, MessageEvent messageEvent) throws Exception;
+  
+  /**
+   * EventSource calls this method when it has received a comment line from the stream (any line starting with a colon).
+   * @param comment the comment line
+   * @throws Exception throwing an exception here will cause it to be logged and also sent to {@link #onError(Throwable)}
+   */
   void onComment(String comment) throws Exception;
+  
   /**
    * This method will be called for all exceptions that occur on the socket connection (including
    * an {@link UnsuccessfulResponseException} if the server returns an unexpected HTTP status),

--- a/src/main/java/com/launchdarkly/eventsource/EventParser.java
+++ b/src/main/java/com/launchdarkly/eventsource/EventParser.java
@@ -34,6 +34,11 @@ public class EventParser {
     this.connectionHandler = connectionHandler;
   }
 
+  /**
+   * Accepts a single line of input and updates the parser state. If this completes a valid event,
+   * the event is sent to the {@link EventHandler}.
+   * @param line an input line
+   */
   public void line(String line) {
     logger.debug("Parsing line: " + line);
     int colonIndex;

--- a/src/main/java/com/launchdarkly/eventsource/EventSource.java
+++ b/src/main/java/com/launchdarkly/eventsource/EventSource.java
@@ -52,6 +52,7 @@ public class EventSource implements ConnectionHandler, Closeable {
   private final Headers headers;
   private final String method;
   @Nullable private final RequestBody body;
+  private final RequestTransformer requestTransformer;
   private final ExecutorService eventExecutor;
   private final ExecutorService streamExecutor;
   private long reconnectTimeMs;
@@ -74,6 +75,7 @@ public class EventSource implements ConnectionHandler, Closeable {
     this.headers = addDefaultHeaders(builder.headers);
     this.method = builder.method;
     this.body = builder.body;
+    this.requestTransformer = builder.requestTransformer;
     this.reconnectTimeMs = builder.reconnectTimeMs;
     this.maxReconnectTimeMs = builder.maxReconnectTimeMs;
     this.backoffResetThresholdMs = builder.backoffResetThresholdMs;
@@ -158,6 +160,7 @@ public class EventSource implements ConnectionHandler, Closeable {
       }
     }
   }
+  
   Request buildRequest() {
     Request.Builder builder = new Request.Builder()
         .headers(headers)
@@ -167,7 +170,9 @@ public class EventSource implements ConnectionHandler, Closeable {
     if (lastEventId != null && !lastEventId.isEmpty()) {
       builder.addHeader("Last-Event-ID", lastEventId);
     }
-    return builder.build();
+    
+    Request request = builder.build();
+    return requestTransformer == null ? request : requestTransformer.transformRequest(request);
   }
 
   private void connect() {
@@ -353,6 +358,36 @@ public class EventSource implements ConnectionHandler, Closeable {
     this.uri = uri;
   }
 
+  /**
+   * Interface for an object that can modify the network request that the EventSource will make.
+   * Use this in conjunction with {@link Builder#requestTransformer} if you need to set request
+   * properties other than the ones that are already supported by the builder (or if, for
+   * whatever reason, you need to determine the request properties dynamically rather than
+   * setting them to fixed values initially). For example:
+   * <code>
+   * public class RequestTagger implements EventSource.RequestTransformer {
+   *   public Request transformRequest(Request input) {
+   *     return input.newBuilder().tag("hello").build();
+   *   }
+   * }
+   * 
+   * EventSource es = new EventSource.Builder(handler, uri).requestTransformer(new RequestTagger()).build();
+   * </code>
+   * 
+   * @since 1.9.0
+   */
+  public static interface RequestTransformer {
+    /**
+     * Returns a request that is either the same as the input request or based on it. When
+     * this method is called, EventSource has already set all of its standard properties on
+     * the request.
+     * 
+     * @param input the original request
+     * @return the request that will be used
+     */
+    public Request transformRequest(Request input);
+  }
+  
   public static final class Builder {
     private String name = "";
     private long reconnectTimeMs = DEFAULT_RECONNECT_TIME_MS;
@@ -365,6 +400,7 @@ public class EventSource implements ConnectionHandler, Closeable {
     private Proxy proxy;
     private Authenticator proxyAuthenticator = null;
     private String method = "GET";
+    private RequestTransformer requestTransformer = null;
     @Nullable private RequestBody body = null;
     private OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder()
             .connectionPool(new ConnectionPool(1, 1, TimeUnit.SECONDS))
@@ -403,6 +439,19 @@ public class EventSource implements ConnectionHandler, Closeable {
       return this;
     }
 
+    /**
+     * Specifies an object that will be used to customize outgoing requests. See {@link RequestTransformer} for details.
+     * 
+     * @param requestTransformer the transformer object
+     * @return the builder
+     * 
+     * @since 1.9.0
+     */
+    public Builder requestTransformer(@Nullable RequestTransformer requestTransformer) {
+      this.requestTransformer = requestTransformer;
+      return this;
+    }
+    
     /**
      * Set the name for this EventSource client to be used when naming the logger and threadpools. This is mainly useful when
      * multiple EventSource clients exist within the same process.

--- a/src/main/java/com/launchdarkly/eventsource/EventSource.java
+++ b/src/main/java/com/launchdarkly/eventsource/EventSource.java
@@ -48,7 +48,7 @@ public class EventSource implements ConnectionHandler, Closeable {
   static final int DEFAULT_BACKOFF_RESET_THRESHOLD_MS = 1000 * 60;
 
   private final String name;
-  private volatile URI uri;
+  private volatile HttpUrl url;
   private final Headers headers;
   private final String method;
   @Nullable private final RequestBody body;
@@ -71,7 +71,7 @@ public class EventSource implements ConnectionHandler, Closeable {
   EventSource(Builder builder) {
     this.name = builder.name;
     this.logger = LoggerFactory.getLogger(EventSource.class.getCanonicalName() + "." + name);
-    this.uri = builder.uri;
+    this.url = builder.url;
     this.headers = addDefaultHeaders(builder.headers);
     this.method = builder.method;
     this.body = builder.body;
@@ -110,7 +110,7 @@ public class EventSource implements ConnectionHandler, Closeable {
       return;
     }
     logger.debug("readyState change: " + RAW + " -> " + CONNECTING);
-    logger.info("Starting EventSource client using URI: " + uri);
+    logger.info("Starting EventSource client using URI: " + url);
     streamExecutor.execute(new Runnable() {
       public void run() {
         connect();
@@ -164,7 +164,7 @@ public class EventSource implements ConnectionHandler, Closeable {
   Request buildRequest() {
     Request.Builder builder = new Request.Builder()
         .headers(headers)
-        .url(uri.toASCIIString())
+        .url(url)
         .method(method, body);
 
     if (lastEventId != null && !lastEventId.isEmpty()) {
@@ -209,7 +209,7 @@ public class EventSource implements ConnectionHandler, Closeable {
               bufferedSource.close();
             }
             bufferedSource = Okio.buffer(response.body().source());
-            EventParser parser = new EventParser(uri, handler, EventSource.this);
+            EventParser parser = new EventParser(url.uri(), handler, EventSource.this);
             for (String line; !Thread.currentThread().isInterrupted() && (line = bufferedSource.readUtf8LineStrict()) != null; ) {
               parser.line(line);
             }
@@ -350,14 +350,53 @@ public class EventSource implements ConnectionHandler, Closeable {
     this.lastEventId = lastEventId;
   }
 
+  /**
+   * Returns the current stream endpoint as an OkHttp HttpUrl.
+   * 
+   * @since 1.9.0
+   */
+  public HttpUrl getHttpUrl() {
+    return this.url;
+  }
+  
+  /**
+   * Returns the current stream endpoint as a java.net.URI.
+   */
   public URI getUri() {
-    return this.uri;
+    return this.url.uri();
   }
 
+  /**
+   * Changes the stream endpoint. This change will not take effect until the next time the
+   * EventSource attempts to make a connection.
+   * 
+   * @param url the new endpoint, as an OkHttp HttpUrl
+   * @throws IllegalArgumentException if the parameter is null or if the scheme is not HTTP or HTTPS
+   * 
+   * @since 1.9.0
+   */
+  public void setHttpUrl(HttpUrl url) {
+    if (url == null) {
+      throw badUrlException();
+    }
+    this.url = url;
+  }
+  
+  /**
+   * Changes the stream endpoint. This change will not take effect until the next time the
+   * EventSource attempts to make a connection.
+   * 
+   * @param url the new endpoint, as a java.net.URI
+   * @throws IllegalArgumentException if the parameter is null or if the scheme is not HTTP or HTTPS
+   */
   public void setUri(URI uri) {
-    this.uri = uri;
+    setHttpUrl(uri == null ? null : HttpUrl.get(uri));
   }
 
+  private static IllegalArgumentException badUrlException() {
+    return new IllegalArgumentException("URI/URL must not be null and must be HTTP or HTTPS");
+  }
+  
   /**
    * Interface for an object that can modify the network request that the EventSource will make.
    * Use this in conjunction with {@link Builder#requestTransformer} if you need to set request
@@ -388,12 +427,15 @@ public class EventSource implements ConnectionHandler, Closeable {
     public Request transformRequest(Request input);
   }
   
+  /**
+   * Builder for {@link EventSource}.
+   */
   public static final class Builder {
     private String name = "";
     private long reconnectTimeMs = DEFAULT_RECONNECT_TIME_MS;
     private long maxReconnectTimeMs = DEFAULT_MAX_RECONNECT_TIME_MS;
     private long backoffResetThresholdMs = DEFAULT_BACKOFF_RESET_THRESHOLD_MS;
-    private final URI uri;
+    private final HttpUrl url;
     private final EventHandler handler;
     private ConnectionErrorHandler connectionErrorHandler = ConnectionErrorHandler.DEFAULT;
     private Headers headers = Headers.of();
@@ -409,11 +451,37 @@ public class EventSource implements ConnectionHandler, Closeable {
             .writeTimeout(DEFAULT_WRITE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
             .retryOnConnectionFailure(true);
 
+    /**
+     * Creates a new builder.
+     * 
+     * @param handler the event handler
+     * @param uri the endpoint as a java.net.URI
+     * @throws IllegalArgumentException if either argument is null, or if the endpoint is not HTTP or HTTPS
+     */
     public Builder(EventHandler handler, URI uri) {
-      this.uri = uri;
-      this.handler = handler;
+      this(handler, uri == null ? null : HttpUrl.get(uri));
     }
 
+    /**
+     * Creates a new builder.
+     * 
+     * @param handler the event handler
+     * @param uri the endpoint as an OkHttp HttpUrl
+     * @throws IllegalArgumentException if either argument is null, or if the endpoint is not HTTP or HTTPS
+     * 
+     * @since 1.9.0
+     */
+    public Builder(EventHandler handler, HttpUrl url) {
+      if (handler == null) {
+        throw new IllegalArgumentException("handler must not be null");
+      }
+      if (url == null) {
+        throw badUrlException();
+      }
+      this.url = url;
+      this.handler = handler;
+    }
+    
     /**
      * Set the HTTP method used for this EventSource client to use for requests to establish the EventSource.
      *
@@ -613,6 +681,10 @@ public class EventSource implements ConnectionHandler, Closeable {
       return this;
     }
 
+    /**
+     * Constructs an {@link EventSource} using the builder's current properties.
+     * @return the new EventSource instance
+     */
     public EventSource build() {
       if (proxy != null) {
         clientBuilder.proxy(proxy);

--- a/src/main/java/com/launchdarkly/eventsource/MessageEvent.java
+++ b/src/main/java/com/launchdarkly/eventsource/MessageEvent.java
@@ -2,29 +2,54 @@ package com.launchdarkly.eventsource;
 
 import java.net.URI;
 
+/**
+ * Event information that is passed to {@link EventHandler#onMessage(String, MessageEvent)}.
+ */
 public class MessageEvent {
   private final String data;
   private final String lastEventId;
   private final URI origin;
 
+  /**
+   * Constructs a new instance.
+   * @param data the event data, if any
+   * @param lastEventId the event ID, if any
+   * @param origin the stream endpoint
+   */
   public MessageEvent(String data, String lastEventId, URI origin) {
     this.data = data;
     this.lastEventId = lastEventId;
     this.origin = origin;
   }
 
+  /**
+   * Constructs a new instance.
+   * @param data the event data, if any
+   */
   public MessageEvent(String data) {
     this(data, null, null);
   }
 
+  /**
+   * Returns the event data, if any.
+   * @return the data string or null
+   */
   public String getData() {
     return data;
   }
 
+  /**
+   * Returns the event ID, if any.
+   * @return the event ID or null
+   */
   public String getLastEventId() {
     return lastEventId;
   }
 
+  /**
+   * Returns the endpoint of the stream that generated the event.
+   * @return the stream URI
+   */
   public URI getOrigin() {
     return origin;
   }

--- a/src/main/java/com/launchdarkly/eventsource/ReadyState.java
+++ b/src/main/java/com/launchdarkly/eventsource/ReadyState.java
@@ -1,9 +1,27 @@
 package com.launchdarkly.eventsource;
 
+/**
+ * Enum values that can be returned by {@link EventSource#getState()}.
+ */
 public enum ReadyState {
+  /**
+   * The EventSource's {@link EventSource#start()} method has not yet been called.
+   */
   RAW,
+  /**
+   * The EventSource is attempting to make a connection.
+   */
   CONNECTING,
+  /**
+   * The connection is active and the EventSource is listening for events.
+   */
   OPEN,
+  /**
+   * The connection has been closed or has failed, and the EventSource will attempt to reconnect.
+   */
   CLOSED,
+  /**
+   * The connection has been permanently closed and will not reconnect.
+   */
   SHUTDOWN
 }

--- a/src/main/java/com/launchdarkly/eventsource/UnsuccessfulResponseException.java
+++ b/src/main/java/com/launchdarkly/eventsource/UnsuccessfulResponseException.java
@@ -1,14 +1,26 @@
 package com.launchdarkly.eventsource;
 
+/**
+ * Exception class that means the remote server returned an HTTP error.
+ */
+@SuppressWarnings("serial")
 public class UnsuccessfulResponseException extends Exception {
 
   private final int code;
 
+  /**
+   * Constructs an exception instance.
+   * @param code the HTTP status
+   */
   public UnsuccessfulResponseException(int code) {
     super("Unsuccessful response code received from stream: " + code);
     this.code = code;
   }
 
+  /**
+   * Returns the HTTP status code.
+   * @return the HTTP status
+   */
   public int getCode() {
     return code;
   }


### PR DESCRIPTION
## [1.9.0] - 2018-12-12
### Added:
- The `requestTransformer` option allows you to customize the outgoing request in any way you like. ([#28](https://github.com/launchdarkly/okhttp-eventsource/issues/28))
- It is now possible to specify the endpoint as either a `URI` or an OkHttp `HttpUrl`. ([#29](https://github.com/launchdarkly/okhttp-eventsource/issues/29))
- The `backoffResetThresholdMs` option controls the new backoff behavior described below.
- Added Javadoc comments for all public members.

### Changed:
- The exponential backoff behavior when a stream connection fails has changed as follows. Previously, the backoff delay would increase for each attempt if the connection could not be made at all, or if a read timeout happened; but if a connection was made and then an error (other than a timeout) occurred, the delay would be reset to the minimum value. Now, the delay is only reset if a stream connection is made and remains open for at least `backoffResetThresholdMs` milliseconds. The default for this value is one minute (60000).