### PR TITLE
Propagate server response to exception

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.10.0
+version=1.11.0-SNAPSHOT
 ossrhUsername=
 ossrhPassword=

--- a/src/main/java/com/launchdarkly/eventsource/EventSource.java
+++ b/src/main/java/com/launchdarkly/eventsource/EventSource.java
@@ -256,7 +256,7 @@ public class EventSource implements ConnectionHandler, Closeable {
             }
           } else {
             logger.debug("Unsuccessful Response: " + response);
-            errorHandlerAction = dispatchError(new UnsuccessfulResponseException(response.code()));
+            errorHandlerAction = dispatchError(new UnsuccessfulResponseException(response));
           }
         } catch (EOFException eofe) {
           logger.warn("Connection unexpectedly closed.");

--- a/src/main/java/com/launchdarkly/eventsource/UnsuccessfulResponseException.java
+++ b/src/main/java/com/launchdarkly/eventsource/UnsuccessfulResponseException.java
@@ -1,20 +1,30 @@
 package com.launchdarkly.eventsource;
 
+import okhttp3.Response;
+
 /**
  * Exception class that means the remote server returned an HTTP error.
  */
 @SuppressWarnings("serial")
 public class UnsuccessfulResponseException extends Exception {
 
-  private final int code;
+  private final Response response;
 
   /**
    * Constructs an exception instance.
    * @param code the HTTP status
    */
   public UnsuccessfulResponseException(int code) {
-    super("Unsuccessful response code received from stream: " + code);
-    this.code = code;
+    this(new Response.Builder().code(code).build());
+  }
+
+  /**
+   * Constructs an exception instance.
+   * @param response {@link Response} provided by server
+   */
+  public UnsuccessfulResponseException(Response response) {
+    super("Unsuccessful response code received from stream: " + response.code());
+    this.response = response;
   }
 
   /**
@@ -22,6 +32,14 @@ public class UnsuccessfulResponseException extends Exception {
    * @return the HTTP status
    */
   public int getCode() {
-    return code;
+    return response.code();
+  }
+
+  /**
+   * Returns the HTTP {@link Response}.
+   * @return the HTTP {@link Response}
+   */
+  public Response getResponse() {
+    return response;
   }
 }


### PR DESCRIPTION
It is often the case (especially for HTTP status 500) when many details are hidden in the headers/body of the HTTP server response.

Since `OkHttp` library already constructs and provides the `Response` object, it makes sense to propagate it to the library's client code via `UnsuccessfulResponseException`.