### PR TITLE
Separates backoff delay logic for testability into BackoffCalculator

### DIFF
--- a/src/main/java/com/launchdarkly/eventsource/BackoffCalculator.java
+++ b/src/main/java/com/launchdarkly/eventsource/BackoffCalculator.java
@@ -1,0 +1,90 @@
+package com.launchdarkly.eventsource;
+
+import java.util.Random;
+
+public class BackoffCalculator {
+
+  private final Random jitter = new Random();
+
+  private long maxReconnectTimeMs;
+  private long reconnectTimeMs;
+  private long backoffResetThresholdMs;
+  private int retryCount;
+
+  /**
+   * A calculator for deriving jittered backoff durations, based upon the quantity of consecutive
+   * short-lived connections preceding each calculation request.
+   *
+   * @param maxReconnectTimeMs The maximum backoff delay in milliseconds
+   * @param reconnectTimeMs The base backoff delay in milliseconds. This value grows exponentially
+   *                        with each short-lived connection until `maxReconnectTime` is reached.
+   * @param backoffResetThresholdMs The duration a connection must have been alive for before it is
+   *                                considered to be long-lived.
+   */
+  public BackoffCalculator(long maxReconnectTimeMs, long reconnectTimeMs, long backoffResetThresholdMs) {
+    this.maxReconnectTimeMs = maxReconnectTimeMs;
+    this.reconnectTimeMs = reconnectTimeMs;
+    this.backoffResetThresholdMs = backoffResetThresholdMs;
+  }
+
+  public long delayAfterConnectedFor(long connectedDuration) {
+    retryCount = connectedDuration >= backoffResetThresholdMs
+        ? 0
+        : retryCount + 1;
+    return delayGivenRetryCount();
+  }
+
+  public long getBackoffResetThresholdMs() {
+    return backoffResetThresholdMs;
+  }
+
+  public void setBackoffResetThresholdMs(long backoffResetThresholdMs) {
+    this.backoffResetThresholdMs = backoffResetThresholdMs;
+  }
+
+  public long getMaxReconnectTimeMs() {
+    return maxReconnectTimeMs;
+  }
+
+  public void setMaxReconnectTimeMs(long maxReconnectTimeMs) {
+    this.maxReconnectTimeMs = maxReconnectTimeMs;
+  }
+
+  public long getReconnectTimeMs() {
+    return reconnectTimeMs;
+  }
+
+  public void setReconnectTimeMs(long reconnectTimeMs) {
+    this.reconnectTimeMs = reconnectTimeMs;
+  }
+
+  private long delayGivenRetryCount() {
+    if (retryCount == 0) {
+      return 0;
+    }
+    long jitterVal = Math.min(maxReconnectTimeMs, reconnectTimeMs * pow2(retryCount));
+    return jitterVal / 2 + nextLong(jitter, jitterVal) / 2;
+  }
+
+  // Returns 2**k, or Integer.MAX_VALUE if 2**k would overflow
+  private int pow2(int k) {
+    return (k < Integer.SIZE - 1) ? (1 << k) : Integer.MAX_VALUE;
+  }
+
+  // Adapted from http://stackoverflow.com/questions/2546078/java-random-long-number-in-0-x-n-range
+  // Since ThreadLocalRandom.current().nextLong(n) requires Android 5
+  private long nextLong(Random rand, long bound) {
+    if (bound <= 0) {
+      throw new IllegalArgumentException("bound must be positive");
+    }
+
+    long r = rand.nextLong() & Long.MAX_VALUE;
+    long m = bound - 1L;
+    if ((bound & m) == 0) { // i.e., bound is a power of 2
+      r = (bound * r) >> (Long.SIZE - 1);
+    } else {
+      for (long u = r; u - (r = u % bound) + m < 0L; u = rand.nextLong() & Long.MAX_VALUE) ;
+    }
+    return r;
+  }
+}

--- a/src/test/java/com/launchdarkly/eventsource/BackoffCalculatorTest.java
+++ b/src/test/java/com/launchdarkly/eventsource/BackoffCalculatorTest.java
@@ -1,0 +1,52 @@
+package com.launchdarkly.eventsource;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static com.launchdarkly.eventsource.EventSource.DEFAULT_BACKOFF_RESET_THRESHOLD_MS;
+import static com.launchdarkly.eventsource.EventSource.DEFAULT_MAX_RECONNECT_TIME_MS;
+import static com.launchdarkly.eventsource.EventSource.DEFAULT_RECONNECT_TIME_MS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BackoffCalculatorTest {
+
+  @Test
+  public void respectsDefaultMaximumBackoffTime() {
+    BackoffCalculator calculator = subject();
+    for (int i = 0; i < 300; i++) {
+      assertTrue(calculator.delayAfterConnectedFor(0) < calculator.getMaxReconnectTimeMs());
+    }
+  }
+
+  @Test
+  public void respectsCustomMaximumBackoffTime() {
+    BackoffCalculator calculator = new BackoffCalculator(5000, 2000, 100);
+    for (int i = 0; i < 300; i++) {
+      assertTrue(calculator.delayAfterConnectedFor(0) < calculator.getMaxReconnectTimeMs());
+    }
+  }
+
+  @Test
+  public void resetsDelayToZeroAfterSuccess() {
+    BackoffCalculator calculator = subject();
+    assertTrue(calculator.delayAfterConnectedFor(0) > 0);
+    assertEquals(0, calculator.delayAfterConnectedFor(calculator.getBackoffResetThresholdMs()));
+  }
+
+  @Test
+  public void delayIncreasesOnSubsequentFailures() {
+    BackoffCalculator calculator = subject();
+    long priorDelay = 0;
+    for (int i = 0; i < 5; i++) {
+      long thisDelay = calculator.delayAfterConnectedFor(0);
+      assertTrue(thisDelay > priorDelay);
+      priorDelay = thisDelay;
+    }
+  }
+
+  private BackoffCalculator subject() {
+    return new BackoffCalculator(DEFAULT_MAX_RECONNECT_TIME_MS,
+        DEFAULT_RECONNECT_TIME_MS, DEFAULT_BACKOFF_RESET_THRESHOLD_MS);
+  }
+}

--- a/src/test/java/com/launchdarkly/eventsource/EventSourceHttpTest.java
+++ b/src/test/java/com/launchdarkly/eventsource/EventSourceHttpTest.java
@@ -13,7 +13,7 @@ import okhttp3.mockwebserver.SocketPolicy;
 
 public class EventSourceHttpTest {
   private static final int CHUNK_SIZE = 5;
-  
+
   @Test
   public void eventSourceReadsChunkedResponse() throws Exception {
     String body = "data: data-by-itself\n\n" +
@@ -30,30 +30,30 @@ public class EventSourceHttpTest {
     try (MockWebServer server = new MockWebServer()) {
       server.enqueue(createEventsResponse(body, SocketPolicy.KEEP_OPEN));
       server.start();
-      
+
       try (EventSource es = new EventSource.Builder(handler, server.url("/"))
           .build()) {
         es.start();
-        
+
         assertEquals(LogItem.opened(), handler.log.take());
-        
+
         assertEquals(LogItem.event("message", "data-by-itself"), // "message" is the default event name, per SSE spec
             handler.log.take());
 
         assertEquals(LogItem.event("event-with-data", "abc"),
             handler.log.take());
- 
+
         assertEquals(LogItem.comment("this is a comment"),
             handler.log.take());
-  
+
         assertEquals(LogItem.event("event-with-more-data-and-id",  "abc\ndef", "my-id"),
             handler.log.take());
       }
-      
+
       assertEquals(LogItem.closed(), handler.log.take());
     }
   }
-  
+
   @Test
   public void eventSourceReconnectsAfterSocketClosed() throws Exception {
     String body1 = "data: first\n\n";
@@ -65,25 +65,25 @@ public class EventSourceHttpTest {
       server.enqueue(createEventsResponse(body1, SocketPolicy.DISCONNECT_AT_END));
       server.enqueue(createEventsResponse(body2, SocketPolicy.KEEP_OPEN));
       server.start();
-      
+
       try (EventSource es = new EventSource.Builder(handler, server.url("/"))
           .reconnectTimeMs(10)
           .build()) {
         es.start();
-        
+
         assertEquals(LogItem.opened(), handler.log.take());
-        
+
         assertEquals(LogItem.event("message", "first"),
             handler.log.take());
 
         assertEquals(LogItem.closed(), handler.log.take());
-       
+
         assertEquals(LogItem.opened(), handler.log.take());
 
         assertEquals(LogItem.event("message", "second"),
             handler.log.take());
       }
-      
+
       assertEquals(LogItem.closed(), handler.log.take());
     }
   }
@@ -98,21 +98,21 @@ public class EventSourceHttpTest {
       server.enqueue(createErrorResponse(500));
       server.enqueue(createEventsResponse(body, SocketPolicy.KEEP_OPEN));
       server.start();
-      
+
       try (EventSource es = new EventSource.Builder(handler, server.url("/"))
           .reconnectTimeMs(10)
           .build()) {
         es.start();
-       
+
         assertEquals(LogItem.error(new UnsuccessfulResponseException(500)),
             handler.log.take());
-        
+
         assertEquals(LogItem.opened(), handler.log.take());
-        
+
         assertEquals(LogItem.event("message", "good"),
             handler.log.take());
       }
-      
+
       assertEquals(LogItem.closed(), handler.log.take());
     }
   }
@@ -129,47 +129,47 @@ public class EventSourceHttpTest {
       server.enqueue(createErrorResponse(500));
       server.enqueue(createEventsResponse(body2, SocketPolicy.KEEP_OPEN));
       server.start();
-      
+
       try (EventSource es = new EventSource.Builder(handler, server.url("/"))
           .reconnectTimeMs(10)
           .build()) {
         es.start();
-       
+
         assertEquals(LogItem.opened(), handler.log.take());
-        
+
         assertEquals(LogItem.event("message", "first"),
             handler.log.take());
-        
+
         assertEquals(LogItem.closed(), handler.log.take());
-        
+
         assertEquals(LogItem.error(new UnsuccessfulResponseException(500)),
             handler.log.take());
-        
+
         assertEquals(LogItem.opened(), handler.log.take());
-        
+
         assertEquals(LogItem.event("message", "second"),
             handler.log.take());
       }
-      
+
       assertEquals(LogItem.closed(), handler.log.take());
     }
   }
-  
+
   private MockResponse createEventsResponse(String body, SocketPolicy socketPolicy) {
     return new MockResponse()
         .setHeader("Content-Type", "text/event-stream")
         .setChunkedBody(body, CHUNK_SIZE)
         .setSocketPolicy(socketPolicy);
   }
-  
+
   private MockResponse createErrorResponse(int status) {
-    return new MockResponse().setResponseCode(500);
+    return new MockResponse().setResponseCode(status);
   }
-  
+
   static class LogItem {
     private final String action;
     private final String[] params;
-    
+
     private LogItem(String action, String[] params) {
       this.action = action;
       this.params = params;
@@ -178,31 +178,31 @@ public class EventSourceHttpTest {
     public static LogItem opened() {
       return new LogItem("opened", null);
     }
-    
+
     public static LogItem closed() {
       return new LogItem("closed", null);
     }
-    
+
     public static LogItem event(String eventName, String data) {
       return event(eventName, data, null);
     }
 
     public static LogItem event(String eventName, String data, String eventId) {
       if (eventId == null) {
-        
+
       }
       return new LogItem("event", eventId == null ? new String[] { eventName, data } :
         new String[] { eventName, data, eventId });
     }
-    
+
     public static LogItem comment(String comment) {
       return new LogItem("comment", new String[] { comment });
     }
-    
+
     public static LogItem error(Throwable t) {
       return new LogItem("error", new String[] { t.toString() });
     }
-    
+
     public String toString() {
       StringBuilder sb = new StringBuilder().append(action);
       if (params != null) {
@@ -217,35 +217,35 @@ public class EventSourceHttpTest {
       }
       return sb.toString();
     }
-    
+
     public boolean equals(Object o) {
       return (o instanceof LogItem) && toString().equals(o.toString());
     }
-    
+
     public int hashCode() {
       return toString().hashCode();
     }
   }
-  
+
   static class TestHandler implements EventHandler {
     public final BlockingQueue<LogItem> log = new ArrayBlockingQueue<>(100);
-    
+
     public void onOpen() throws Exception {
       log.add(LogItem.opened());
     }
-    
+
     public void onMessage(String event, MessageEvent messageEvent) throws Exception {
       log.add(LogItem.event(event, messageEvent.getData(), messageEvent.getLastEventId()));
     }
-    
+
     public void onError(Throwable t) {
       log.add(LogItem.error(t));
     }
-    
+
     public void onComment(String comment) throws Exception {
       log.add(LogItem.comment(comment));
     }
-    
+
     @Override
     public void onClosed() throws Exception {
       log.add(LogItem.closed());

--- a/src/test/java/com/launchdarkly/eventsource/EventSourceTest.java
+++ b/src/test/java/com/launchdarkly/eventsource/EventSourceTest.java
@@ -1,24 +1,22 @@
 package com.launchdarkly.eventsource;
 
-import okhttp3.Headers;
-import okhttp3.HttpUrl;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.OkHttpClient.Builder;
-import okio.Buffer;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.net.Proxy;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.OkHttpClient.Builder;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okio.Buffer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -47,18 +45,18 @@ public class EventSourceTest {
     EventSource es = new EventSource.Builder(mock(EventHandler.class), STREAM_HTTP_URL).build();
     assertEquals(STREAM_URI, es.getUri());
   }
-  
+
   @Test
   public void hasExpectedHttpUrlWhenInitializedWithUri() {
     assertEquals(STREAM_HTTP_URL, eventSource.getHttpUrl());
   }
-  
+
   @Test
   public void hasExpectedHttpUrlWhenInitializedWithHttpUrl() {
     EventSource es = new EventSource.Builder(mock(EventHandler.class), STREAM_HTTP_URL).build();
     assertEquals(STREAM_HTTP_URL, es.getHttpUrl());
   }
-  
+
   @Test(expected=IllegalArgumentException.class)
   public void handlerCannotBeNull() {
     new EventSource.Builder(null, STREAM_URI);
@@ -97,31 +95,10 @@ public class EventSourceTest {
     eventSource.setHttpUrl(url);
     assertEquals(url, eventSource.getHttpUrl());
   }
-  
+
   @Test(expected=IllegalArgumentException.class)
   public void cannotSetHttpUrlToNull() {
     eventSource.setHttpUrl(null);
-  }
-  
-  @Test
-  public void respectsDefaultMaximumBackoffTime() {
-    eventSource.setReconnectionTimeMs(2000);
-    assertEquals(EventSource.DEFAULT_MAX_RECONNECT_TIME_MS, eventSource.getMaxReconnectTimeMs());
-    Assert.assertTrue(eventSource.backoffWithJitter(300) < eventSource.getMaxReconnectTimeMs());
-  }
-
-  @Test
-  public void respectsCustomMaximumBackoffTime() {
-    eventSource.setReconnectionTimeMs(2000);
-    eventSource.setMaxReconnectTimeMs(5000);
-    Assert.assertTrue(eventSource.backoffWithJitter(300) < eventSource.getMaxReconnectTimeMs());
-  }
-
-  @Ignore("Useful for inspecting jitter values empirically")
-  public void inspectJitter() {
-    for (int i = 0; i < 100; i++) {
-      System.out.println("With jitter, retry " + i + ": " + eventSource.backoffWithJitter(i));
-    }
   }
 
   @Test
@@ -190,7 +167,7 @@ public class EventSourceTest {
 
     assertEquals(writeTimeout, client.writeTimeoutMillis());
   }
-  
+
   @Test
   public void customMethod() throws IOException {
     builder.method("report");
@@ -217,7 +194,7 @@ public class EventSourceTest {
     assertEquals("GET", req.method());
     assertEquals(null, req.body());
   }
-  
+
   @Test
   public void customHeaders() throws IOException {
     Headers headers = new Headers.Builder()
@@ -231,7 +208,7 @@ public class EventSourceTest {
     assertEquals(Arrays.<String>asList("text/event-stream"), req.headers().values("Accept"));
     assertEquals(Arrays.<String>asList("no-cache"), req.headers().values("Cache-Control"));
   }
-  
+
   @Test
   public void customHeadersOverwritingDefaults() throws IOException {
     Headers headers = new Headers.Builder()


### PR DESCRIPTION
The jittered backoff delay calculation is extracted into a separate class.
Additionally, the logic has been modified such that there is no reconnection delay after a long-lived connection. Backoff is only performed when the connection was short-lived.