### PR TITLE
Fix connection leaks after closing non-exhaustive EventSource.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
     testImplementation("com.google.guava:guava:32.0.1-jre")
     testImplementation("junit:junit:4.12")
     testImplementation("org.hamcrest:hamcrest-all:1.3")
+    testImplementation("org.easytesting:fest-reflect:1.4.1")
 }
 
 checkstyle {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
     testImplementation("com.google.guava:guava:32.0.1-jre")
     testImplementation("junit:junit:4.12")
     testImplementation("org.hamcrest:hamcrest-all:1.3")
+    // Inspect private fields in tests.
     testImplementation("org.easytesting:fest-reflect:1.4.1")
 }
 

--- a/src/main/java/com/launchdarkly/eventsource/EventSource.java
+++ b/src/main/java/com/launchdarkly/eventsource/EventSource.java
@@ -309,12 +309,13 @@ public class EventSource implements Closeable {
           // transparently.
           continue;
         }
-        // The ErrorStrategy told us to THROW rather than CONTINUE. 
+        // The ErrorStrategy told us to THROW rather than CONTINUE.
         throw exception;
       }
       
       
-      connectionCloser.set(clientResult.getCloser());
+      connectionCloser.set(clientResult.getConnectionCloser());
+      responseCloser.set(clientResult.getResponseCloser());
       origin = clientResult.getOrigin() == null ? client.getOrigin() : clientResult.getOrigin();
       connectedTime = System.currentTimeMillis();
       logger.debug("Connected to SSE stream");
@@ -696,7 +697,6 @@ public class EventSource implements Closeable {
             logger.warn("Unexpected error when closing response: {}", LogValues.exceptionSummary(e));
           }
         }
-        eventParser = null;
         readyState.compareAndSet(ReadyState.OPEN, ReadyState.CLOSED);
         readyState.compareAndSet(ReadyState.CONNECTING, ReadyState.CLOSED);
         // If the current thread is not the reading thread, these fields will be updated the
@@ -951,7 +951,7 @@ public class EventSource implements Closeable {
      *   // import com.launchdarkly.logging.*;
      *   
      *   builder.logger(
-     *      LDLogger.withAdapter(Logs.basic(), "logname") 
+     *      LDLogger.withAdapter(Logs.basic(), "logname")
      *   );
      * </code></pre>
      * <p>
@@ -990,16 +990,16 @@ public class EventSource implements Closeable {
      * first and {@code event:} second, {@link MessageEvent#getEventName()} will <i>not</i> contain the value of
      * {@code event:} but will be {@link MessageEvent#DEFAULT_EVENT_NAME} instead; similarly, an {@code id:} field will
      * be ignored if it appears after {@code data:} in this mode. Therefore, you should only use this mode if the
-     * server's behavior is predictable in this regard.</li>  
+     * server's behavior is predictable in this regard.</li>
      * <li> The SSE protocol specifies that an event should be processed only if it is terminated by a blank line, but
      * in this mode the handler will receive the event as soon as a {@code data:} field appears-- so, if the stream
      * happens to cut off abnormally without a trailing blank line, technically you will be receiving an incomplete
      * event that should have been ignored. You will know this has happened ifbecause reading from the Reader throws
      * a {@link StreamClosedWithIncompleteMessageException}.</li>
-     * </ul>  
+     * </ul>
      * 
      * @param streamEventData true if events should be dispatched immediately with asynchronous data rather than
-     *   read fully before dispatch 
+     *   read fully before dispatch
      * @return the builder
      * @see #expectFields(String...)
      * @since 2.6.0

--- a/src/main/java/com/launchdarkly/eventsource/EventSource.java
+++ b/src/main/java/com/launchdarkly/eventsource/EventSource.java
@@ -32,7 +32,7 @@ import okhttp3.HttpUrl;
  * The client uses a pull model where the caller starts the EventSource and then requests
  * data from it synchronously on a single thread. The initial connection attempt is made
  * when you call {@link #start()}, or when you first attempt to read an event.
- * 
+ *
  * To read events from the stream, you can either request them one at a time by calling
  * {@link #readMessage()} or {@link #readAnyEvent()}, or consume them in a loop by calling
  * {@link #messages()} or {@link #anyEvents()}. The "message" methods assume you are only
@@ -70,11 +70,11 @@ public class EventSource implements Closeable {
    * The default value for {@link Builder#readBufferSize(int)}.
    */
   public static final int DEFAULT_READ_BUFFER_SIZE = 1000;
-  
+
   // Note that some fields have package-private visibility for tests.
-  
+
   private final Object sleepNotifier = new Object();
-  
+
   // The following final fields are set from the configuration builder.
   private final ConnectStrategy.Client client;
   final int readBufferSize;
@@ -83,7 +83,7 @@ public class EventSource implements Closeable {
   final long retryDelayResetThresholdMillis;
   final boolean streamEventData;
   final Set<String> expectFields;
-  
+
   // The following mutable fields are not volatile because they should only be
   // accessed from the thread that is reading from EventSource.
   private EventParser eventParser;
@@ -97,6 +97,7 @@ public class EventSource implements Closeable {
   // be modified from other threads if they call stop() or interrupt(). We
   // use AtomicReference because we need atomicity in updates.
   private final AtomicReference<Closeable> connectionCloser = new AtomicReference<>();
+  private final AtomicReference<Closeable> responseCloser = new AtomicReference<>();
   private final AtomicReference<Thread> readingThread = new AtomicReference<>();
   private final AtomicReference<ReadyState> readyState;
 
@@ -104,7 +105,7 @@ public class EventSource implements Closeable {
   // and are read by the thread that is reading the stream.
   private volatile boolean deliberatelyClosedConnection;
   private volatile boolean calledStop;
-  
+
   // These fields are written by the thread that is reading the stream, and can
   // be read by other threads to inspect the state of the stream.
   volatile long baseRetryDelayMillis; // set at config time but may be changed by a "retry:" value
@@ -139,7 +140,7 @@ public class EventSource implements Closeable {
   public URI getOrigin() {
     return origin;
   }
-  
+
   /**
    * Returns the logger that this EventSource is using.
    *
@@ -166,7 +167,7 @@ public class EventSource implements Closeable {
    * This can be set initially with {@link Builder#lastEventId(String)}, and is updated whenever an event
    * is received that has an ID. Whether event IDs are supported depends on the server; it may ignore this
    * value.
-   * 
+   *
    * @return the last known event ID, or null
    * @see Builder#lastEventId(String)
    * @since 2.0.0
@@ -192,7 +193,7 @@ public class EventSource implements Closeable {
   public long getBaseRetryDelayMillis() {
     return baseRetryDelayMillis;
   }
-  
+
   /**
    * Returns the retry delay that will be used for the next reconnection, if the
    * stream has failed.
@@ -212,7 +213,7 @@ public class EventSource implements Closeable {
   public long getNextRetryDelayMillis() {
     return nextReconnectDelayMillis;
   }
-  
+
   /**
    * Attempts to start the stream if it is not already active.
    * <p>
@@ -244,7 +245,7 @@ public class EventSource implements Closeable {
   public void start() throws StreamException {
     tryStart(false);
   }
-  
+
   private FaultEvent tryStart(boolean canReturnFaultEvent) throws StreamException {
     if (eventParser != null) {
       return null;
@@ -253,7 +254,7 @@ public class EventSource implements Closeable {
 
     while (true) {
       StreamException exception = null;
-      
+
       if (nextReconnectDelayMillis > 0) {
         long delayNow = disconnectedTime == 0 ? nextReconnectDelayMillis :
           (nextReconnectDelayMillis - (System.currentTimeMillis() - disconnectedTime));
@@ -279,22 +280,22 @@ public class EventSource implements Closeable {
           }
         }
       }
-      
+
       ConnectStrategy.Client.Result clientResult = null;
-      
+
       if (exception == null) {
         readyState.set(ReadyState.CONNECTING);
-        
+
         connectedTime = 0;
         deliberatelyClosedConnection = calledStop = false;
-        
+
         try {
           clientResult = client.connect(lastEventId);
         } catch (StreamException e) {
           exception = e;
         }
       }
-      
+
       if (exception != null) {
         disconnectedTime = System.currentTimeMillis();
         computeReconnectDelay();
@@ -308,16 +309,18 @@ public class EventSource implements Closeable {
           // transparently.
           continue;
         }
-        // The ErrorStrategy told us to THROW rather than CONTINUE. 
+        // The ErrorStrategy told us to THROW rather than CONTINUE.
         throw exception;
       }
-      
-      
-      connectionCloser.set(clientResult.getCloser());
+
+
+      connectionCloser.set(clientResult.getConnectionCloser());
+      responseCloser.set(clientResult.getResponseCloser());
+
       origin = clientResult.getOrigin() == null ? client.getOrigin() : clientResult.getOrigin();
       connectedTime = System.currentTimeMillis();
       logger.debug("Connected to SSE stream");
-      
+
       eventParser = new EventParser(
           clientResult.getInputStream(),
           clientResult.getOrigin(),
@@ -326,14 +329,14 @@ public class EventSource implements Closeable {
           expectFields,
           logger
           );
-      
+
       readyState.set(ReadyState.OPEN);
 
       currentErrorStrategy = baseErrorStrategy;
       return null;
     }
   }
-  
+
   /**
    * Attempts to receive a message from the stream.
    * <p>
@@ -347,7 +350,7 @@ public class EventSource implements Closeable {
    * <p>
    * This method must be called from the same thread that first started using the
    * stream (that is, the thread that called {@link #start()} or read the first event).
-   * 
+   *
    * @return an SSE message
    * @throws StreamException if there is an error and retry is not enabled
    * @see #readAnyEvent()
@@ -362,7 +365,7 @@ public class EventSource implements Closeable {
       }
     }
   }
-  
+
   /**
    * Attempts to receive an event of any kind from the stream.
    * <p>
@@ -417,7 +420,7 @@ public class EventSource implements Closeable {
       }
     };
   }
-  
+
   /**
    * Returns an iterable sequence of events.
    * <p>
@@ -528,7 +531,7 @@ public class EventSource implements Closeable {
     if (currentState == SHUTDOWN) {
       return;
     }
-    
+
     closeCurrentStream(true, true);
     try {
       client.close();
@@ -552,12 +555,12 @@ public class EventSource implements Closeable {
   // Iterator implementation used by messages() and anyEvents()
   private class IteratorImpl<T extends StreamEvent> implements Iterator<T> {
     private final Class<T> filterClass;
-    
+
     IteratorImpl(Class<T> filterClass) {
       this.filterClass = filterClass;
       calledStop = false;
     }
-    
+
     public boolean hasNext() {
       while (true) {
         if (nextEvent != null && filterClass.isAssignableFrom(nextEvent.getClass())) {
@@ -574,7 +577,7 @@ public class EventSource implements Closeable {
         }
       }
     }
-    
+
     public T next() {
       while (nextEvent == null || !filterClass.isAssignableFrom(nextEvent.getClass()) && hasNext()) {}
       @SuppressWarnings("unchecked")
@@ -586,7 +589,7 @@ public class EventSource implements Closeable {
 
   private StreamEvent requireEvent() throws StreamException {
     readingThread.set(Thread.currentThread());
-    
+
     try {
       while (true) {
         // Reading an event implies starting the stream if it isn't already started.
@@ -629,7 +632,7 @@ public class EventSource implements Closeable {
       throw e;
     }
   }
-  
+
   private void resetRetryDelayStrategy() {
     logger.debug("Resetting retry delay strategy to initial state");
     currentRetryDelayStrategy = baseRetryDelayStrategy;
@@ -642,7 +645,7 @@ public class EventSource implements Closeable {
     }
     return errorStrategyResult.getAction();
   }
-  
+
   private void computeReconnectDelay() {
     if (retryDelayResetThresholdMillis > 0 && connectedTime != 0) {
       long connectionDurationMillis = System.currentTimeMillis() - connectedTime;
@@ -660,11 +663,12 @@ public class EventSource implements Closeable {
 
   private boolean closeCurrentStream(boolean deliberatelyInterrupted, boolean shouldStopIterating) {
     Closeable oldConnectionCloser = this.connectionCloser.getAndSet(null);
+
     Thread oldReadingThread = readingThread.getAndSet(null);
     if (oldConnectionCloser == null && oldReadingThread == null) {
       return false;
     }
-    
+
     synchronized (sleepNotifier) { // this synchronization prevents a race condition in start()
       if (deliberatelyInterrupted) {
         this.deliberatelyClosedConnection = true;
@@ -681,18 +685,31 @@ public class EventSource implements Closeable {
         }
       }
       if (oldReadingThread == Thread.currentThread()) {
+        Closeable oldResponseCloser = this.responseCloser.getAndSet(null);
         eventParser = null;
+        // Response can only be closed from reading thread. Otherwise, it will cause
+        // java.lang.IllegalStateException: Unbalanced enter/exit raised from okhttp
+        // since closing response will drain remaining chunks if exists, resulting in concurrent buffer source reading.
+        // which may conflict with reading thread.
+        if (oldResponseCloser != null) {
+          try {
+            oldResponseCloser.close();
+            logger.debug("Closed response");
+          } catch (IOException e) {
+            logger.warn("Unexpected error when closing response: {}", LogValues.exceptionSummary(e));
+          }
+        }
         readyState.compareAndSet(ReadyState.OPEN, ReadyState.CLOSED);
         readyState.compareAndSet(ReadyState.CONNECTING, ReadyState.CLOSED);
         // If the current thread is not the reading thread, these fields will be updated the
         // next time the reading thread tries to do a read.
       }
-      
+
       sleepNotifier.notify(); // in case we're sleeping in a reconnect delay, wake us up
     }
     return true;
   }
-  
+
   /**
    * Builder for configuring {@link EventSource}.
    */
@@ -725,7 +742,7 @@ public class EventSource implements Closeable {
      * <p>
      * Or, if you want to consume an input stream from some other source, you can
      * create your own subclass of {@link ConnectStrategy}.
-     * 
+     *
      * @param connectStrategy the object that will manage the input stream;
      *   must not be null
      * @since 4.0.0
@@ -779,11 +796,11 @@ public class EventSource implements Closeable {
      * <p>
      * This is the same as {@link #Builder(URI)}, but using the OkHttp type
      * {@link HttpUrl}.
-     * 
+     *
      * @param url the stream URL
      * @throws IllegalArgumentException if the argument is null, or if the endpoint
      *   is not HTTP or HTTPS
-     * 
+     *
      * @since 1.9.0
      * @see #Builder(ConnectStrategy)
      * @see #Builder(URI)
@@ -792,7 +809,7 @@ public class EventSource implements Closeable {
     public Builder(HttpUrl url) {
       this(ConnectStrategy.http(url));
     }
-    
+
     /**
      * Specifies a strategy for determining whether to handle errors transparently
      * or throw them as exceptions.
@@ -802,7 +819,7 @@ public class EventSource implements Closeable {
      * may instead use alternate {@link ErrorStrategy} implementations, such as
      * {@link ErrorStrategy#alwaysContinue()}, or a custom implementation, to allow
      * EventSource to continue after an error.
-     *  
+     *
      * @param errorStrategy the object that will control error handling; if null,
      *   defaults to {@link ErrorStrategy#alwaysThrow()}
      * @return the builder
@@ -812,7 +829,7 @@ public class EventSource implements Closeable {
       this.errorStrategy = errorStrategy;
       return this;
     }
-    
+
     /**
      * Sets the ID value of the last event received.
      * <p>
@@ -820,7 +837,7 @@ public class EventSource implements Closeable {
      * skip past previously sent events if it supports this behavior. Once the connection is established,
      * this value will be updated whenever an event is received that has an ID. Whether event IDs are
      * supported depends on the server; it may ignore this value.
-     * 
+     *
      * @param lastEventId the last event identifier
      * @return the builder
      * @since 2.0.0
@@ -841,7 +858,7 @@ public class EventSource implements Closeable {
      * If you set the base delay to zero, the backoff logic will not apply-- multiplying by
      * zero gives zero every time. Therefore, use a zero delay with caution since it could
      * cause a reconnect storm during a service interruption.
-     * 
+     *
      * @param retryDelay the base delay, in whatever time unit is specified by {@code timeUnit}
      * @param timeUnit the time unit, or {@code TimeUnit.MILLISECONDS} if null
      * @return the builder
@@ -864,7 +881,7 @@ public class EventSource implements Closeable {
      * is to apply an exponential backoff and jitter. You may instead use a modified
      * version of {@link DefaultRetryDelayStrategy} to customize the backoff and
      * jitter, or a custom implementation with any other logic.
-     *  
+     *
      * @param retryDelayStrategy the object that will control retry delays; if null,
      *   defaults to {@link RetryDelayStrategy#defaultStrategy()}
      * @return the builder
@@ -886,7 +903,7 @@ public class EventSource implements Closeable {
      * connection lasted longer than the threshold, in which case the delay will start over at the
      * initial minimum value. This prevents long delays from occurring on connections that are only
      * rarely restarted.
-     *   
+     *
      * @param retryDelayResetThreshold the minimum time that a connection must stay open to avoid resetting
      *   the delay, in whatever time unit is specified by {@code timeUnit}
      * @param timeUnit the time unit, or {@code TimeUnit.MILLISECONDS} if null
@@ -909,7 +926,7 @@ public class EventSource implements Closeable {
      * Therefore, if an application expects to see many lines in the stream that are longer
      * than {@link EventSource#DEFAULT_READ_BUFFER_SIZE}, it can specify a larger buffer size
      * to avoid unnecessary heap allocations.
-     * 
+     *
      * @param readBufferSize the buffer size
      * @return the builder
      * @throws IllegalArgumentException if the size is less than or equal to zero
@@ -923,7 +940,7 @@ public class EventSource implements Closeable {
       this.readBufferSize = readBufferSize;
       return this;
     }
-    
+
     /**
      * Specifies a custom logger to receive EventSource logging.
      * <p>
@@ -934,14 +951,14 @@ public class EventSource implements Closeable {
      * the basic console logging implementation, and to tag the output with the name "logname":
      * <pre><code>
      *   // import com.launchdarkly.logging.*;
-     *   
+     *
      *   builder.logger(
-     *      LDLogger.withAdapter(Logs.basic(), "logname") 
+     *      LDLogger.withAdapter(Logs.basic(), "logname")
      *   );
      * </code></pre>
      * <p>
      * If you do not provide a logger, the default is there is no log output.
-     * 
+     *
      * @param logger an {@link LDLogger} implementation, or null for no logging
      * @return the builder
      * @since 2.7.0
@@ -975,16 +992,16 @@ public class EventSource implements Closeable {
      * first and {@code event:} second, {@link MessageEvent#getEventName()} will <i>not</i> contain the value of
      * {@code event:} but will be {@link MessageEvent#DEFAULT_EVENT_NAME} instead; similarly, an {@code id:} field will
      * be ignored if it appears after {@code data:} in this mode. Therefore, you should only use this mode if the
-     * server's behavior is predictable in this regard.</li>  
+     * server's behavior is predictable in this regard.</li>
      * <li> The SSE protocol specifies that an event should be processed only if it is terminated by a blank line, but
      * in this mode the handler will receive the event as soon as a {@code data:} field appears-- so, if the stream
      * happens to cut off abnormally without a trailing blank line, technically you will be receiving an incomplete
      * event that should have been ignored. You will know this has happened ifbecause reading from the Reader throws
      * a {@link StreamClosedWithIncompleteMessageException}.</li>
-     * </ul>  
-     * 
+     * </ul>
+     *
      * @param streamEventData true if events should be dispatched immediately with asynchronous data rather than
-     *   read fully before dispatch 
+     *   read fully before dispatch
      * @return the builder
      * @see #expectFields(String...)
      * @since 2.6.0
@@ -1017,7 +1034,7 @@ public class EventSource implements Closeable {
      * <p>
      * Such behavior is not automatic because in some applications, there might never be an {@code event:} field,
      * and EventSource has no way to anticipate this.
-     * 
+     *
      * @param fieldNames a list of SSE field names (case-sensitive; any names other than "event" and "id" are ignored)
      * @return the builder
      * @see #streamEventData(boolean)
@@ -1036,7 +1053,7 @@ public class EventSource implements Closeable {
       }
       return this;
     }
-    
+
     /**
      * Constructs an {@link EventSource} using the builder's current properties.
      * @return the new EventSource instance

--- a/src/main/java/com/launchdarkly/eventsource/HttpConnectStrategy.java
+++ b/src/main/java/com/launchdarkly/eventsource/HttpConnectStrategy.java
@@ -466,6 +466,8 @@ public class HttpConnectStrategy extends ConnectStrategy {
           responseBody.byteStream(),
           uri,
           new RequestCloser(call),
+        // prevent from connection leak warning from okhttp.
+        // see: okhttp3.internal.connection.RealConnectionPool.pruneAndGetAllocationCount
         new ResponseCloser(response)
           );
     }

--- a/src/main/java/com/launchdarkly/eventsource/HttpConnectStrategy.java
+++ b/src/main/java/com/launchdarkly/eventsource/HttpConnectStrategy.java
@@ -465,7 +465,8 @@ public class HttpConnectStrategy extends ConnectStrategy {
       return new Result(
           responseBody.byteStream(),
           uri,
-          new RequestCloser(call)
+          new RequestCloser(call),
+        new ResponseCloser(response)
           );
     }
     
@@ -552,6 +553,19 @@ public class HttpConnectStrategy extends ConnectStrategy {
     public void close() throws IOException {
       // EventSource calls this if it is deliberately stopping the stream via stop() or interrupt().
       call.cancel();
+    }
+  }
+
+  private static class ResponseCloser implements Closeable {
+    private final Response response;
+
+    public ResponseCloser(Response response) {
+      this.response = response;
+    }
+
+    @Override
+    public void close() throws IOException {
+      this.response.close();
     }
   }
 

--- a/src/main/java/com/launchdarkly/eventsource/HttpConnectStrategy.java
+++ b/src/main/java/com/launchdarkly/eventsource/HttpConnectStrategy.java
@@ -466,10 +466,10 @@ public class HttpConnectStrategy extends ConnectStrategy {
           responseBody.byteStream(),
           uri,
           new RequestCloser(call),
-        // prevent from connection leak warning from okhttp.
-        // see: okhttp3.internal.connection.RealConnectionPool.pruneAndGetAllocationCount
-        new ResponseCloser(response)
-          );
+          // prevent from connection leak warning from okhttp.
+          // see: okhttp3.internal.connection.RealConnectionPool.pruneAndGetAllocationCount
+          new ResponseCloser(response)
+      );
     }
     
     public void close() {

--- a/src/test/java/com/launchdarkly/eventsource/HttpConnectStrategyTest.java
+++ b/src/test/java/com/launchdarkly/eventsource/HttpConnectStrategyTest.java
@@ -319,7 +319,7 @@ public class HttpConnectStrategyTest {
         int n = stream.read(b, 0, 5);
         assertThat(n, equalTo(5));
         
-        result.getCloser().close();
+        result.getConnectionCloser().close();
         // This causes us to call the OkHttp method Call.cancel(). The InputStream is
         // expected to throw an IOException on the next read, but it would also be
         // acceptable for it to return EOF (-1).
@@ -371,7 +371,7 @@ public class HttpConnectStrategyTest {
     try (HttpServer server = HttpServer.start(Handlers.status(200))) {
       try (ConnectStrategy.Client client = hcs.uri(server.getUri()).createClient(testLogger.getLogger())) {
         ConnectStrategy.Client.Result result = client.connect(lastEventId);
-        result.getCloser().close();
+        result.getConnectionCloser().close();
 
         return server.getRecorder().requireRequest();
       }

--- a/src/test/java/com/launchdarkly/eventsource/HttpConnectStrategyWithEventSourceTest.java
+++ b/src/test/java/com/launchdarkly/eventsource/HttpConnectStrategyWithEventSourceTest.java
@@ -4,12 +4,18 @@ import com.launchdarkly.testhelpers.httptest.Handler;
 import com.launchdarkly.testhelpers.httptest.Handlers;
 import com.launchdarkly.testhelpers.httptest.HttpServer;
 
+import org.fest.reflect.reference.TypeRef;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.Closeable;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static com.launchdarkly.eventsource.TestUtils.interruptOnAnotherThread;
+import static com.launchdarkly.eventsource.TestUtils.interruptOnAnotherThreadAfterDelay;
+import static org.fest.reflect.core.Reflection.field;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Tests of basic EventSource behavior using real HTTP requests.
@@ -26,14 +32,14 @@ public class HttpConnectStrategyWithEventSourceTest {
         Handlers.SSE.event("b", "data2"),
         Handlers.hang()
         );
-    
+
     try (HttpServer server = HttpServer.start(response)) {
       try (EventSource es = new EventSource.Builder(server.getUri()).build()) {
         es.start();
-        
+
         assertThat(es.readAnyEvent(), equalTo(
             new MessageEvent("a", "data1", null, es.getOrigin())));
-  
+
         assertThat(es.readAnyEvent(), equalTo(
             new MessageEvent("b", "data2", null, es.getOrigin())));
       }
@@ -59,13 +65,13 @@ public class HttpConnectStrategyWithEventSourceTest {
           .retryDelay(1, null)
           .build()) {
         es.start();
-        
+
         assertThat(es.readAnyEvent(), equalTo(new MessageEvent("message", "first", null, es.getOrigin())));
-        
+
         assertThat(es.readAnyEvent(), equalTo(new FaultEvent(new StreamClosedByServerException())));
-        
+
         assertThat(es.readAnyEvent(), equalTo(new StartedEvent()));
-        
+
         assertThat(es.readAnyEvent(), equalTo(new MessageEvent("message", "second", null, es.getOrigin())));
       }
     }
@@ -91,17 +97,80 @@ public class HttpConnectStrategyWithEventSourceTest {
           .retryDelay(1, null)
           .build()) {
         es.start();
-        
+
         assertThat(es.readAnyEvent(), equalTo(new MessageEvent("message", "first", null, es.getOrigin())));
-        
+
         interruptOnAnotherThread(es);
 
         assertThat(es.readAnyEvent(), equalTo(new FaultEvent(new StreamClosedByCallerException())));
-        
+
         assertThat(es.readAnyEvent(), equalTo(new StartedEvent()));
-        
+
         assertThat(es.readAnyEvent(), equalTo(new MessageEvent("message", "second", null, es.getOrigin())));
       }
+    }
+  }
+
+  @Test
+  public void eventSourceReconnectsAfterExternallyInterruptedWithNewEventParser() throws Exception {
+    Handler response1 = Handlers.all(
+      Handlers.SSE.start(),
+      Handlers.SSE.event("message", "first"),
+      Handlers.SSE.leaveOpen()
+    );
+    Handler response2 = Handlers.all(
+      Handlers.SSE.start(),
+      Handlers.SSE.event("message", "second"),
+      Handlers.SSE.leaveOpen()
+    );
+    Handler allResponses = Handlers.sequential(response1, response2);
+
+    try (HttpServer server = HttpServer.start(allResponses)) {
+      AtomicReference<EventSource> holder = new AtomicReference<>();
+      try (EventSource es = new EventSource.Builder(server.getUri())
+        .errorStrategy(ErrorStrategy.alwaysContinue())
+        .retryDelay(1, null)
+        .build()) {
+        es.start();
+        holder.set(es);
+        AtomicReference<Closeable> connectionCloser = field("connectionCloser").ofType(new TypeRef<AtomicReference<Closeable>>() {
+        }).in(es).get();
+        AtomicReference<Closeable> responseCloser = field("responseCloser").ofType(new TypeRef<AtomicReference<Closeable>>() {
+        }).in(es).get();
+
+        assertThat(es.readAnyEvent(), equalTo(new MessageEvent("message", "first", null, es.getOrigin())));
+
+        interruptOnAnotherThread(es).join();
+
+        assertThat(connectionCloser.get(), nullValue());
+        // Response should be closed with reading thread.
+        assertThat(responseCloser.get(), notNullValue());
+
+        assertThat(es.readAnyEvent(), equalTo(new FaultEvent(new StreamClosedByCallerException())));
+
+        // All closed.
+        assertThat(connectionCloser.get(), nullValue());
+
+        assertThat(responseCloser.get(), nullValue());
+
+
+        assertThat(es.readAnyEvent(), equalTo(new StartedEvent()));
+        // All recreated
+        assertThat(connectionCloser.get(), notNullValue());
+
+        assertThat(responseCloser.get(), notNullValue());
+
+        assertThat(es.readAnyEvent(), equalTo(new MessageEvent("message", "second", null, es.getOrigin())));
+      }
+      AtomicReference<Closeable> connectionCloser = field("connectionCloser").ofType(new TypeRef<AtomicReference<Closeable>>() {
+      }).in(holder.get()).get();
+      AtomicReference<Closeable> responseCloser = field("responseCloser").ofType(new TypeRef<AtomicReference<Closeable>>() {
+      }).in(holder.get()).get();
+
+      // All closed by try-with-resource statement
+      assertThat(connectionCloser.get(), nullValue());
+
+      assertThat(responseCloser.get(), nullValue());
     }
   }
 }

--- a/src/test/java/com/launchdarkly/eventsource/TestUtils.java
+++ b/src/test/java/com/launchdarkly/eventsource/TestUtils.java
@@ -13,21 +13,24 @@ public class TestUtils {
     return sb.toString();
   }
 
-  public static void interruptOnAnotherThreadAfterDelay(EventSource es, long delayMillis) {
-    new Thread(new Runnable() {
+  public static Thread interruptOnAnotherThreadAfterDelay(EventSource es, long delayMillis) {
+    Thread t = new Thread(new Runnable() {
       public void run() {
         try {
           if (delayMillis > 0) {
             Thread.sleep(delayMillis);
           }
-        } catch (InterruptedException e) {}
+        } catch (InterruptedException e) {
+        }
         es.interrupt();
       }
-    }).start();
+    });
+    t.start();
+    return t;
   }
   
-  public static void interruptOnAnotherThread(EventSource es) {
-    interruptOnAnotherThreadAfterDelay(es, 0);
+  public static Thread interruptOnAnotherThread(EventSource es) {
+    return interruptOnAnotherThreadAfterDelay(es, 0);
   }
 
   public static void interruptThisThreadFromAnotherThreadAfterDelay(long delayMillis) {


### PR DESCRIPTION
## Affected version
4.1.1

## Problem
Okhttp connection won't closed properly after closing EventSource when SSE stream is not fully consumed.

## Reproduce code

```java
package moe.nemesiss.playground;

import com.launchdarkly.eventsource.ConnectStrategy;
import com.launchdarkly.eventsource.EventSource;
import com.launchdarkly.eventsource.MessageEvent;
import okhttp3.ConnectionPool;
import okhttp3.HttpUrl;
import okhttp3.OkHttpClient;

import java.util.logging.Level;
import java.util.logging.Logger;

import static org.fest.reflect.core.Reflection.field;
import static org.fest.reflect.core.Reflection.method;

public class EventSourceLeakDemo {

    private static HttpUrl streamGeneratorUrlFor(int length, int interval) {
        // A self-hosted SSE stream generator.
        return HttpUrl.get(String.format("https://plugins.nemesiss.xyz/main/stream_generator?length=%s&intervalMs=%s", length, interval));
    }

    public static void main(String[] args) throws InterruptedException {
        EventSource closedEventSource;
        Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);

        try (EventSource source = new EventSource.Builder(
                // Obtain a stream with 10 MessageEvents
                ConnectStrategy.http(streamGeneratorUrlFor(10, 200))).build()) {

            // Actually consumes 8 message and gone.
            for (int i = 0; i < 8; i++) {
                try {
                    MessageEvent message = source.readMessage();
                    System.out.println(message.getData());
                } catch (Throwable t) {
                    t.printStackTrace();
                    break;
                }
            }
            closedEventSource = source;
        }

        // Here EventSource was closed since leaving try-with-resource block.

        // GC WeakReference hosted in connection.
        // see: okhttp3.internal.connection.RealConnection.getCalls
        System.gc();

        // Trigger connection pool cleanup manually.
        // these reflection calls are equivalent to statement:
        // ((com.launchdarkly.eventsource.HttpConnectStrategy.Client) closedEventSource).client.connectionPool().delegate.cleanup(System.nanoTime());
        ConnectStrategy.Client client = field("client").ofType(ConnectStrategy.Client.class).in(closedEventSource).get();
        OkHttpClient internalOkHttpClient = field("httpClient").ofType(OkHttpClient.class).in(client).get();
        ConnectionPool cp = internalOkHttpClient.connectionPool();
        method("cleanup").withReturnType(long.class).withParameterTypes(long.class).in(cp.getDelegate$okhttp()).invoke(System.nanoTime());
        // And connection leak warning should be shown in terminal like below:
        // index: 0, timestamp: 1704600618813
        // index: 1, timestamp: 1704600619016
        // index: 2, timestamp: 1704600619220
        // index: 3, timestamp: 1704600619424
        // index: 4, timestamp: 1704600619628
        // index: 5, timestamp: 1704600619833
        // index: 6, timestamp: 1704600620037
        // index: 7, timestamp: 1704600620240
        //Jan 07, 2024 12:10:20 PM okhttp3.internal.platform.Platform log
        //WARNING: A connection to https://plugins.nemesiss.xyz/ was leaked. Did you forget to close a response body?
        //java.lang.Throwable: response.body().close()
        //	at okhttp3.internal.platform.Platform.getStackTraceForCloseable(Platform.kt:145)
        //	at okhttp3.internal.connection.RealCall.callStart(RealCall.kt:170)
        //	at okhttp3.internal.connection.RealCall.execute(RealCall.kt:151)
        //	at com.launchdarkly.eventsource.HttpConnectStrategy$Client.connect(HttpConnectStrategy.java:452)
        //	at com.launchdarkly.eventsource.EventSource.tryStart(EventSource.java:292)
        //	at com.launchdarkly.eventsource.EventSource.requireEvent(EventSource.java:595)
        //	at com.launchdarkly.eventsource.EventSource.readAnyEvent(EventSource.java:390)
        //	at com.launchdarkly.eventsource.EventSource.readMessage(EventSource.java:359)
        //	at moe.nemesiss.playground.EventSourceLeakDemo.main(EventSourceLeakDemo.java:33)
        // Jan 07, 2024 12:10:20 PM okhttp3.internal.platform.Platform log
    }
}
```

## Reason

1. `com.launchdarkly.eventsource.EventSource#close` will close underlying `okhttp3.Call` and package-private `com.launchdarkly.eventsource.HttpConnectStrategy.Client#httpClient` if there is no specified httpClient from outside.

2. Canceling a `okhttp3.Call` will:

   * close underlying Socket (for http1.1) or Stream (for http2) will call stack below:

   ```
     java.lang.Thread.State: RUNNABLE
   	  at okhttp3.internal.connection.Exchange.cancel(Exchange.kt:153)
   	  at okhttp3.internal.connection.RealCall.cancel(RealCall.kt:139)
   	  at com.launchdarkly.eventsource.HttpConnectStrategy$RequestCloser.close(HttpConnectStrategy.java:554)
   	  at com.launchdarkly.eventsource.EventSource.closeCurrentStream(EventSource.java:677)
   	  - locked <0x916> (a java.lang.Object)
   	  at com.launchdarkly.eventsource.EventSource.close(EventSource.java:532)
   ```

   * close connection pool and dispatcher for httpClient created internally (if exists).

3. Condition for logging connection leak warning: connection.calls is not empty, but referring 'RealCall' was gone by GC, indicating RealCall was not detached with RealConnection properly. 

   ```kotlin
   internal class CallReference(
       referent: RealCall,
       /**
        * Captures the stack trace at the time the Call is executed or enqueued. This is helpful for
        * identifying the origin of connection leaks.
        */
       val callStackTrace: Any?
     ) : WeakReference<RealCall>(referent)
   
   private fun pruneAndGetAllocationCount(connection: RealConnection, now: Long): Int {
       connection.assertThreadHoldsLock()
   
       val references: MutableList<Reference<RealCall>> = connection.calls
       var i = 0
       // connection.calls is not empty
       while (i < references.size) {
         val reference: Reference<RealCall> = references[i]
   
         if (reference.get() != null) {
           i++
           continue
         }
         // But referring 'RealCall' was gone by GC.
         // Indicates RealCall was not detached with RealConnection properly.
         
         // We've discovered a leaked call. This is an application bug.
         val callReference = reference as CallReference
         val message = "A connection to ${connection.route().address.url} was leaked. " +
             "Did you forget to close a response body?"
         Platform.get().logCloseableLeak(message, callReference.callStackTrace)
   
         references.removeAt(i)
         connection.noNewExchanges = true
   
         // If this was the last allocation, the connection is eligible for immediate eviction.
         if (references.isEmpty()) {
           connection.idleAtNs = now - keepAliveDurationNs
           return 0
         }
       }
   
       return references.size
     }
   ```

4. **The only way to initiative detach RealCall with RealConnection properly is calling `releaseConnectionNoEvents` method**, which entrance is in `messageDone` method.

   * Called from stream exhausted:

     ```
     "main@1" prio=5 tid=0x1 nid=NA runnable
       java.lang.Thread.State: RUNNABLE
     	  at okhttp3.internal.connection.RealCall.releaseConnectionNoEvents$okhttp(RealCall.kt:381)
     	  at okhttp3.internal.connection.RealCall.callDone(RealCall.kt:350)
     	  - locked <0x8b2> (a okhttp3.internal.connection.RealConnection)
     	  at okhttp3.internal.connection.RealCall.messageDone$okhttp(RealCall.kt:309)
     	  at okhttp3.internal.connection.Exchange.bodyComplete(Exchange.kt:193)
     	  at okhttp3.internal.connection.Exchange$ResponseBodySource.complete(Exchange.kt:324)
     	  at okhttp3.internal.connection.Exchange$ResponseBodySource.read(Exchange.kt:284)
     	  at okio.RealBufferedSource$inputStream$1.read(RealBufferedSource.kt:158)
     	  at com.launchdarkly.eventsource.BufferedLineParser.readMoreIntoBuffer(BufferedLineParser.java:138)
     	  at com.launchdarkly.eventsource.BufferedLineParser.read(BufferedLineParser.java:63)
     	  at com.launchdarkly.eventsource.EventParser.getNextChunk(EventParser.java:267)
     	  at com.launchdarkly.eventsource.EventParser.tryNextEvent(EventParser.java:130)
     	  at com.launchdarkly.eventsource.EventParser.nextEvent(EventParser.java:109)
     	  at com.launchdarkly.eventsource.EventSource.requireEvent(EventSource.java:600)
     	  at com.launchdarkly.eventsource.EventSource.readAnyEvent(EventSource.java:392)
     	  at com.launchdarkly.eventsource.EventSource.readMessage(EventSource.java:361)
     	  at moe.nemesiss.playground.EventSourceLeakDemo.main(EventSourceLeakDemo.java:34)
     ```

   * Called from closing Response.

     ```
     "main@1" prio=5 tid=0x1 nid=NA runnable
       java.lang.Thread.State: RUNNABLE
     	  at okhttp3.internal.connection.RealCall.releaseConnectionNoEvents$okhttp(RealCall.kt:381)
     	  at okhttp3.internal.connection.RealCall.callDone(RealCall.kt:350)
     	  - locked <0x8b3> (a okhttp3.internal.connection.RealConnection)
     	  at okhttp3.internal.connection.RealCall.messageDone$okhttp(RealCall.kt:309)
     	  at okhttp3.internal.connection.Exchange.bodyComplete(Exchange.kt:193)
     	  at okhttp3.internal.connection.Exchange$ResponseBodySource.complete(Exchange.kt:324)
     	  at okhttp3.internal.connection.Exchange$ResponseBodySource.close(Exchange.kt:310)
     	  at okio.RealBufferedSource.close(RealBufferedSource.kt:392)
     	  at okhttp3.internal.Util.closeQuietly(Util.kt:495)
     	  at okhttp3.ResponseBody.close(ResponseBody.kt:192)
     	  at okhttp3.Response.close(Response.kt:302)
     	  at com.launchdarkly.eventsource.HttpConnectStrategy$ResponseCloser.close(HttpConnectStrategy.java:570)
     	  at com.launchdarkly.eventsource.EventSource.closeCurrentStream(EventSource.java:694)
     	  - locked <0x923> (a java.lang.Object)
     	  at com.launchdarkly.eventsource.EventSource.close(EventSource.java:534)
     	  at moe.nemesiss.playground.EventSourceLeakDemo.main(EventSourceLeakDemo.java:42)
     ```
     
   
5.  But such method cannot be called either closing `Call` or closing connection pool. Closing `Call` is obvious, let's focus on closing conneciton pool.
   
      ```kotlin
      // com.launchdarkly.eventsource.HttpConnectStrategy.Client#close
      public void close() {
        // We need to shut down the HTTP client *if* it is one that we created, and not
        // one that the application provided to us.
        OkHttpClient preconfiguredClient = HttpConnectStrategy.this.httpClient;      
        if (preconfiguredClient == null) {
          // COVERAGE: these null guards are here for safety but in practice the values are never null and there
          // is no way to cause them to be null in unit tests
          if (httpClient.connectionPool() != null) {
            httpClient.connectionPool().evictAll(); // evict calls from connection pool.
          }
          if (httpClient.dispatcher() != null) {
            httpClient.dispatcher().cancelAll();
            if (httpClient.dispatcher().executorService() != null) {
              httpClient.dispatcher().executorService().shutdownNow();
            }
          }
        }
      }
      
      // okhttp3.internal.connection.RealConnectionPool#evictAll
      fun evictAll() {
        val i = connections.iterator()
        while (i.hasNext()) {
          val connection = i.next()
          val socketToClose = synchronized(connection) {
            if (connection.calls.isEmpty()) { // false, closing 'Call' will not detach call with connection.
              i.remove() 
              connection.noNewExchanges = true
              return@synchronized connection.socket() 
            } else {
              return@synchronized null
            }
          }
          socketToClose?.closeQuietly() // close socket (equivalent to closing 'Call').
        }
        if (connections.isEmpty()) cleanupQueue.cancelAll()
      }
      ```



## Possible Fixup

Close underlying `Response` in closeCurrentStream along with closing `Call` at reading thread.

![image](https://github.com/launchdarkly/okhttp-eventsource/assets/10548832/c0f537c3-c6d4-46fd-8ea6-894c24bb981e)
