### PR TITLE
chore: update release please permission and adds CI unit tests to release process

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -1,0 +1,57 @@
+name: Shared CI
+description: Shared build, style, test, and coverage steps for okhttp-eventsource.
+inputs:
+  java_version:
+    description: 'Java version to use (e.g. 8, 11, 17).'
+    required: true
+  run_tests:
+    description: 'If true, run unit tests, coverage report, and coverage verification.'
+    required: false
+    default: 'true'
+  run_contract_tests:
+    description: 'If true, run SSE contract tests (slower; needs network).'
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{ inputs.java_version }}
+
+    - name: Restore dependencies
+      shell: bash
+      run: ./gradlew dependencies
+
+    - name: Build jar
+      shell: bash
+      run: ./gradlew jar
+
+    - name: Checkstyle
+      shell: bash
+      run: ./gradlew checkstyleMain
+
+    - name: Unit tests
+      if: ${{ inputs.run_tests == 'true' }}
+      shell: bash
+      run: make test
+
+    - name: Generate test coverage report
+      if: ${{ inputs.run_tests == 'true' }}
+      shell: bash
+      run: |
+        ./gradlew jacocoTestReport
+        mkdir -p coverage/
+        cp -r build/reports/jacoco/test/* ./coverage
+
+    - name: Enforce test coverage
+      if: ${{ inputs.run_tests == 'true' }}
+      shell: bash
+      run: ./gradlew jacocoTestCoverageVerification
+
+    - name: Contract tests
+      if: ${{ inputs.run_contract_tests == 'true' }}
+      shell: bash
+      run: make contract-tests

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -8,10 +8,6 @@ inputs:
     description: 'If true, run unit tests, coverage report, and coverage verification.'
     required: false
     default: 'true'
-  run_contract_tests:
-    description: 'If true, run SSE contract tests (slower; needs network).'
-    required: false
-    default: 'false'
 
 runs:
   using: composite
@@ -50,8 +46,3 @@ runs:
       if: ${{ inputs.run_tests == 'true' }}
       shell: bash
       run: ./gradlew jacocoTestCoverageVerification
-
-    - name: Contract tests
-      if: ${{ inputs.run_contract_tests == 'true' }}
-      shell: bash
-      run: make contract-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,30 +15,19 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: false
+      fail-fast: false # false = do not cancel sibling matrix jobs when one leg fails
       matrix:
         java-version: ["8", "11", "17"]
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+
+      - name: Shared CI
+        uses: ./.github/actions/ci
         with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: ${{ matrix.java-version }}
-
-      - run: ./gradlew dependencies
-      - run: ./gradlew jar
-      - run: ./gradlew checkstyleMain
-
-      - run: make test
-
-      - name: Generate test coverage report
-        run: |
-            ./gradlew jacocoTestReport
-            mkdir -p coverage/
-            cp -r build/reports/jacoco/test/* ./coverage
-      - name: Enforce test coverage
-        run: ./gradlew jacocoTestCoverageVerification
+          java_version: ${{ matrix.java-version }}
+          run_tests: true
+          run_contract_tests: true
 
       - name: Save test results
         run: |
@@ -55,9 +44,6 @@ jobs:
           name: ${{ matrix.java-version }} code coverage
           path: ./coverage
 
-      - name: run contract tests
-        run: make contract-tests
-
   windows:
     runs-on: windows-latest
 
@@ -66,7 +52,7 @@ jobs:
         shell: powershell
 
     strategy:
-      fail-fast: false
+      fail-fast: false # false = do not cancel sibling matrix jobs when one leg fails
       matrix:
         java-version: ["11.0.2.01", "17.0.1"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           java_version: ${{ matrix.java-version }}
           run_tests: true
-          run_contract_tests: true
 
       - name: Save test results
         run: |
@@ -43,6 +42,10 @@ jobs:
         with:
           name: ${{ matrix.java-version }} code coverage
           path: ./coverage
+
+      # After junit/coverage artifacts: contract test failures must not skip uploads above.
+      - name: Contract tests
+        run: make contract-tests
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,25 @@ on:
         required: true
 
 jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # false = do not cancel sibling matrix jobs when one leg fails
+      matrix:
+        java-version: ["8", "11", "17"]
+    steps:
+      # https://github.com/actions/checkout/releases/tag/v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Shared CI
+        uses: ./.github/actions/ci
+        with:
+          java_version: ${{ matrix.java-version }}
+          run_tests: ${{ inputs.run_tests }}
+          run_contract_tests: false
+
   build-and-publish:
+    needs: ci
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           java_version: ${{ matrix.java-version }}
           run_tests: ${{ inputs.run_tests }}
-          run_contract_tests: false
 
   build-and-publish:
     needs: ci

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,9 @@ jobs:
 
   call-workflow-publish:
     needs: release-please
+    permissions:
+      id-token: write
+      contents: write
     uses: ./.github/workflows/publish.yml
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to GitHub Actions workflow wiring and permissions, with no runtime/library code changes. Main risk is CI/release pipeline behavior changes (e.g., matrix gating or permission scoping) affecting publish reliability.
> 
> **Overview**
> Introduces a reusable composite action (`.github/actions/ci`) that centralizes Java setup, Gradle build/checkstyle, and optional unit test + JaCoCo coverage/verification steps.
> 
> Updates the main `ci.yml` workflow to call this shared action for the Linux Java matrix, while keeping artifact uploads and ensuring contract tests run *after* uploads.
> 
> Extends `publish.yml` to run the same CI matrix as a prerequisite (`needs: ci`) before `build-and-publish`, and grants the `release-please.yml` publish workflow call the required `id-token`/`contents` permissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edae3f7d699bad33116027b49452669823404298. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->