### PR TITLE
chore(deps): bump okhttp to v5.3.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ java {
 
 object Versions {
     const val launchdarklyLogging = "1.1.1"
-    const val okhttp = "4.12.0"
+    const val okhttp = "5.3.2"
 }
 
 dependencies {


### PR DESCRIPTION
v5.3.2 is the latest version of OkHttp.
Version 5 of OkHttp works on Android 5.0+ (API level 21+) and Java 8+.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrading the core HTTP client dependency can introduce behavioral/compatibility changes at runtime even though the diff is a single version bump.
> 
> **Overview**
> Updates the OkHttp dependency version in `build.gradle.kts` from `4.12.0` to `5.3.2`, so consumers of this library will build and run against OkHttp v5.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03de8848823ff34087d5c3ba67e3c645cb109285. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->