### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Repository Maintainers
+* @launchdarkly/team-sdk-java


### PR DESCRIPTION
## Summary

Adds a `CODEOWNERS` file assigning `@launchdarkly/team-sdk-java` as the default code owners, consistent with other Java SDK repositories (`java-core`, `android-client-sdk`).

Link to Devin session: https://app.devin.ai/sessions/37fa817bb3614d8c8c8dd9de452ccc39
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repository metadata only; no code, build, or runtime impact.
> 
> **Overview**
> Adds a root **`CODEOWNERS`** file so **`@launchdarkly/team-sdk-java`** is the default owner for all paths (`*`), matching other Java SDK repos.
> 
> This only affects GitHub review routing and ownership metadata—no application or SDK runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ca49df0036c876486c00aff2bca744ebbc31857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->