### PR TITLE
test: fix flaky canIterateEvents test caused by PipedInputStream timing

### DIFF
--- a/src/test/java/com/launchdarkly/eventsource/EventSourceReadingTest.java
+++ b/src/test/java/com/launchdarkly/eventsource/EventSourceReadingTest.java
@@ -303,16 +303,16 @@ public class EventSourceReadingTest {
       }
     }).start();
 
-    StreamEvent e1 = queue.poll(1, TimeUnit.SECONDS);
+    StreamEvent e1 = queue.poll(5, TimeUnit.SECONDS);
     assertThat(e1, equalTo(new StartedEvent()));
     
-    StreamEvent e2 = queue.poll(1, TimeUnit.SECONDS);
+    StreamEvent e2 = queue.poll(5, TimeUnit.SECONDS);
     assertThat(e2, equalTo(new MessageEvent("a", "data1", null, ORIGIN)));
 
-    StreamEvent e3 = queue.poll(1, TimeUnit.SECONDS);
+    StreamEvent e3 = queue.poll(5, TimeUnit.SECONDS);
     assertThat(e3, equalTo(new CommentEvent("nice")));
 
-    StreamEvent e4 = queue.poll(1, TimeUnit.SECONDS);
+    StreamEvent e4 = queue.poll(5, TimeUnit.SECONDS);
     assertThat(e4, equalTo(new MessageEvent("b", "data2", null, ORIGIN)));
 
     assertThat("iterator should not have finished yet because we didn't close the stream",
@@ -321,7 +321,7 @@ public class EventSourceReadingTest {
     stream.close();
     
     assertThat("timed out waiting for iterator on reader thread to finish",
-        iteratorFinished.tryAcquire(1, TimeUnit.SECONDS), is(true));
+        iteratorFinished.tryAcquire(5, TimeUnit.SECONDS), is(true));
   }
 
   @Test


### PR DESCRIPTION
## Summary

`EventSourceReadingTest.canIterateEvents` flakes on CI because `PipedInputStream.read()` has a built-in `wait(1000)` when its buffer is empty. When the pipe writer thread hasn't written data before EventSource starts reading, this causes up to a 1-second delay before data is delivered. The test's `queue.poll(1, TimeUnit.SECONDS)` then races with the arriving data, failing when the timeout expires just as the event is enqueued.

Increases poll timeouts from 1s to 5s in `canIterateEvents`. The tests remain fast because `poll` returns immediately when data arrives.

CI failure: https://github.com/launchdarkly/okhttp-eventsource/actions/runs/27165957135/job/80193033816?pr=106

Link to Devin session: https://app.devin.ai/sessions/49e559fb4a04401dbb09d7cc3535d66b
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout adjustments with no production or library behavior changes.
> 
> **Overview**
> Addresses CI flakiness in **`canIterateEvents`** by widening **`BlockingQueue.poll`** and **`Semaphore.tryAcquire`** waits from **1s to 5s** when the test thread waits on events from a background **`anyEvents()`** iterator.
> 
> The change only affects test synchronization margins against **`PipedInputStream`** timing (up to ~1s when the pipe buffer is empty); **`poll`/`tryAcquire` still return as soon as data is available**, so passing runs should stay fast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3e16cff474fe050e8093487201d57d5c9f5c7fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->